### PR TITLE
Upgrade to pdns cookbook 2 and Debian 8

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,10 +10,7 @@ verifier:
 
 platforms:
   - name: debian-7.8
-
-# This fails for at the `pdns_control reload` step with
-# > Timeout error: Error from remote in receive(): Resource temporarily unavailable
-#  - name: debian-8.2
+  - name: debian-8.5
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,9 +9,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: debian-7.11
-    run_list:
-      - recipe[apt]
   - name: debian-8.6
     run_list:
       - recipe[apt]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,5 +16,5 @@ suites:
   - name: default
     run_list:
       - recipe[t3-pdns::default]
-      - recipe[t3-pdns::test]
+      - recipe[t3-pdns_test::default]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,8 +9,12 @@ verifier:
   name: inspec
 
 platforms:
-  - name: debian-7.8
-  - name: debian-8.5
+  - name: debian-7.11
+    run_list:
+      - recipe[apt]
+  - name: debian-8.6
+    run_list:
+      - recipe[apt]
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://api.berkshelf.com"
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,12 @@
 source "https://api.berkshelf.com"
 
 metadata
+
+def fixture(name)
+  cookbook name, path: "test/fixtures/cookbooks/#{name}"
+end
+
+group :integration do
+  cookbook 'apt'
+  fixture 't3-pdns_test'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,25 +1,11 @@
+default['pdns']['flavor'] = 'authoritative'
+default['pdns']['authoritative']['config']['allow_recursion'] = '127.0.0.1'
+#<> Just a test value
+default['pdns']['authoritative']['config']['allow_axfr_ips'] = ['192.168.1.1']
+default['pdns']['authoritative']['config']['disable_axfr'] = false
 
-include_attribute "pdns::server"
+# default['pdns']['authoritative']['config']['local_ipv6'] = "::1 #{node[:ip6address]}"
+default['pdns']['authoritative']['config']['local_ipv6'] = "::"
 
-# Listen on all Interfaces
-default["pdns"]["server"]["local_address"] = "0.0.0.0"
-default["pdns"]["server"]["local_ipv6"] = "::1 #{node[:ip6address]}"
-
-# Bind Backend related Configuration
-default["pdns"]["server_backend"] = "server"
-default["pdns"]["server"]["launch"] = "bind"
-default["pdns"]["server"]["bind_config"] = "/etc/powerdns/zones/zones.conf"
-
-# disable some default Values which are not available in our Package
-default["pdns"]["server"]["experimental_direct_dnskey"] = nil
-default["pdns"]["server"]["experimental_json_interface"] = nil
-default["pdns"]["server"]["experimental_logfile"] = nil
-default["pdns"]["server"]["edns_subnet_option_number"] = nil
-default["pdns"]["server"]["max_ent_entries"] = nil
-default["pdns"]["server"]["searchdomains"] = nil
-
-# Master related Configuration
-default["pdns"]["server"]["master"] = "yes"
-default["pdns"]["server"]["disable_axfr"] = "no"
-default["pdns"]["server"]["allow_axfr_ips"] = ""
-
+#<> Bind zone configuration (override: this is set with default priority in the authoritative recipe)
+override['pdns']['authoritative']['config']['bind_config'] = '/etc/powerdns/zones.conf'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "steffen.gebert@typo3.org"
 license          "Apache2"
 description      "Installs/Configures t3-pdns"
 long_description "Installs/Configures t3-pdns"
-version          "0.1.6"
+version          "1.0.0"
 
 depends          "pdns", "= 2.4.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      "Installs/Configures t3-pdns"
 long_description "Installs/Configures t3-pdns"
 version          "0.1.6"
 
-depends          "pdns", "~> 0.3.4"
+depends          "pdns", "= 2.4.1"

--- a/providers/zone.rb
+++ b/providers/zone.rb
@@ -23,11 +23,34 @@ end
 
 use_inline_resources
 
+def load_current_resource
+  @current_resource = Chef::Resource::T3PdnsZone.new(new_resource.name)
+
+  @current_resource.name(new_resource.name)
+  @current_resource.exists = ::File.file?("/etc/powerdns/zones/#{new_resource.name}.zone")
+  @current_resource
+end
+
+# Returns the pdns_control reload command, depending on if
+# we create a new zone or update an existing one.
+def reload_command
+
+  if @current_resource.exists
+    log "Zone #{@new_resource.name} already exists. Doing reload."
+    "pdns_control bind-reload-now #{@new_resource.name}"
+  else
+    log "New zone #{@new_resource.name}. Adding."
+    "pdns_control bind-add-zone #{@new_resource.name}"
+  end
+
+end
+
 action :create do
 
   service "pdns"
 
-  execute "pdns_control reload" do
+  execute "reload via pdns_control" do
+    command reload_command
     action :nothing
   end
 
@@ -41,7 +64,7 @@ action :create do
     cookbook  new_resource.cookbook
     mode      0644
     action    :create
-    notifies  :run, "execute[pdns_control reload]"
+    notifies  :run, "execute[reload via pdns_control]"
     variables(
       :serial => serial,
       :serial_modulo => serial.to_i % 2 ** 32 # modulo 2^32

--- a/providers/zone.rb
+++ b/providers/zone.rb
@@ -91,7 +91,7 @@ action :create do
 
   ruby_block "delete zone file inclusion" do
     block do
-      fe = Chef::Util::FileEdit.new("/etc/powerdns/zones/zones.conf")
+      fe = Chef::Util::FileEdit.new(node['pdns']['authoritative']['config']['bind_config'])
       fe.insert_line_if_no_match(/zone "#{new_resource.name}"/,
                                  ['zone "',new_resource.name, '" in { type master; file "/etc/powerdns/zones/', new_resource.name, '.zone"; };'].join)
       fe.write_file
@@ -115,7 +115,7 @@ action :delete do
 
   ruby_block "delete zone file inclusion" do
     block do
-      fe = Chef::Util::FileEdit.new("/etc/powerdns/zones/zones.conf")
+      fe = Chef::Util::FileEdit.new(node['pdns']['authoritative']['config']['bind_config'])
       fe.search_file_delete_line(/zone "#{new_resource.name}"/)
       fe.write_file
     end

--- a/providers/zone.rb
+++ b/providers/zone.rb
@@ -40,7 +40,7 @@ def reload_command
     "pdns_control bind-reload-now #{@new_resource.name}"
   else
     log "New zone #{@new_resource.name}. Adding."
-    "pdns_control bind-add-zone #{@new_resource.name}"
+    "pdns_control bind-add-zone #{@new_resource.name} /etc/powerdns/zones/#{new_resource.name}.zone"
   end
 
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,11 +7,13 @@
 # 
 #
 
-include_recipe "pdns::server"
+include_recipe "pdns::default"
 
-# disable resolvconf which is not useful
-# @see https://github.com/opscode-cookbooks/pdns/pull/11
-resources("resolvconf[custom]").action :nothing
+# Zones (/etc/powerdns/zones.conf)
+file node['pdns']['authoritative']['config']['bind_config'] do
+  mode 0644
+  action :create_if_missing
+end
 
 # Zones Directory
 directory "/etc/powerdns/zones/" do
@@ -19,8 +21,3 @@ directory "/etc/powerdns/zones/" do
   recursive true
 end
 
-# Zones
-file "/etc/powerdns/zones/zones.conf" do
-  mode 0644
-  action :create_if_missing
-end

--- a/resources/zone.rb
+++ b/resources/zone.rb
@@ -37,3 +37,4 @@ attribute :cookbook,
           :kind_of        => String,
           :default        => "t3-pdns"
 
+attr_accessor :exists

--- a/test/fixtures/cookbooks/t3-pdns_test/metadata.rb
+++ b/test/fixtures/cookbooks/t3-pdns_test/metadata.rb
@@ -1,0 +1,6 @@
+name             "t3-pdns_test"
+maintainer       "TYPO3 Association"
+maintainer_email "steffen.gebert@typo3.org"
+license          "Apache 2.0"
+description      "Tests for t3-pdns"
+version          "0.0.0"

--- a/test/fixtures/cookbooks/t3-pdns_test/recipes/create_zone.rb
+++ b/test/fixtures/cookbooks/t3-pdns_test/recipes/create_zone.rb
@@ -11,7 +11,3 @@ t3_pdns_zone "example.com" do
       {:name => "www", :type => "CNAME", :value => "example.org."},
     ])
 end
-
-
-# adds the `dig` command that we use in the serverspec tests
-package "dnsutils"

--- a/test/fixtures/cookbooks/t3-pdns_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/t3-pdns_test/recipes/default.rb
@@ -1,0 +1,5 @@
+# adds the `dig` command that we use in the serverspec tests
+package "dnsutils"
+
+include_recipe "#{cookbook_name}::create_zone"
+include_recipe "#{cookbook_name}::save_attributes"

--- a/test/fixtures/cookbooks/t3-pdns_test/recipes/save_attributes.rb
+++ b/test/fixtures/cookbooks/t3-pdns_test/recipes/save_attributes.rb
@@ -1,0 +1,5 @@
+ruby_block "Save node attributes" do
+  block do
+    File.write("/tmp/kitchen_chef_node.json", node.to_json)
+  end
+end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -6,7 +6,7 @@ control 'pdns-1' do
   end
 
   # this is pretty ugly.. but well..
-  sleep 3
+  sleep 10
 
   describe service('pdns') do
     it { should be_running }

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -20,9 +20,20 @@ control 'pdns-1' do
     its('processes') { should include 'pdns_server-in' }
   end
 
-  # we search for the line "example.com IN A 1.2.3.4" (and match against the IP only)
-  describe command('dig example.com @127.0.0.1') do
-    its(:stdout) { should match /example\.com\..*\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ }
-  end
+  # this file is created in t3-pdns_test::save_attributes
+  node = json('/tmp/kitchen_chef_node.json').params
 
+  # read out all IP addresses of this node
+  ips = node['automatic']['network']['interfaces'].map { |iface_name, iface_data|
+    iface_data['addresses'].select{ |address, address_data|
+      ['inet', 'inet6'].include? address_data['family']
+    }.keys.flatten
+  }
+
+  # we search for the line 'example.com IN A 1.2.3.4' (and match against the IP only)
+  ips.flatten.each do |local_ip|
+    describe command('dig example.com @' + local_ip) do
+      its(:stdout) { should match /example\.com\..*\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ }
+    end
+  end
 end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -8,16 +8,27 @@ control 'pdns-1' do
   # this is pretty ugly.. but well..
   sleep 10
 
-  describe service('pdns') do
-    it { should be_running }
+  # not working in docker
+  # describe service('pdns') do
+  #   it { should be_running }
+  # end
+
+  # great DSL, dear inspec!
+  # Verify that one of each of these processes is running
+  %w{pdns_server pdns_server-instance}.each do |process|
+    describe processes(process) do
+      its('list.length') { should eq(1) }
+    end
   end
+
 
   describe port(53) do
     its('protocols') { should include 'tcp'}
     its('protocols') { should include 'tcp6'}
     its('protocols') { should include 'udp'}
     its('protocols') { should include 'udp'}
-    its('processes') { should include 'pdns_server-in' }
+    # does not work in docker
+    # its('processes') { should include 'pdns_server-in' }
   end
 
   # this file is created in t3-pdns_test::save_attributes


### PR DESCRIPTION
The new cookbook version works on Debian 8 and is also a lot cleaner.

Further, changes were made to the `t3_pdns_zone` resource to make `pdns-server` aware of newly created zones (otherwise tests won't pass).

The test harness was extended to verify that it responds to all IP address. Still, this is something that we should discuss, as the documentation [says as follows](https://doc.powerdns.com/md/authoritative/settings/#local-ipv6):

> `local-ipv6`
> IPv6 Addresses, separated by commas or whitespace
> Default: ::
> Local IPv6 address to which we bind. It is highly advised to bind to specific interfaces and not use the default 'bind to any'. This causes big problems if you have multiple IP addresses.

I could, however, not  make it work to specify `::1 <local-ipv6-address>`, ending up with

>  Fatal error: Unable to bind to UDP ipv6 socket