### PR TITLE
Run named-checkzone to validate zone files

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,8 @@
 
 include_recipe "t3-base"
 
+package 'bind9utils' # for named-checkzone
+
 include_recipe "pdns::default"
 
 # Zones (/etc/powerdns/zones.conf)

--- a/test/fixtures/cookbooks/t3-pdns_test/recipes/create_zone.rb
+++ b/test/fixtures/cookbooks/t3-pdns_test/recipes/create_zone.rb
@@ -4,10 +4,12 @@ t3_pdns_zone "example.com" do
   soa            "ns"
   contact        "admin.example.com"
   global_ttl     300
-  mail_exchange  [{:host => "mail.example.com", :priority => 20}]
-  nameserver     ["a.com"]
+  mail_exchange  [{:host => "mail.example.com.", :priority => 20}]
+  nameserver     ["ns.example.org."]
   records        ([
-      {:name => "@",   :type => "A",     :value => "1.2.3.4"},
-      {:name => "www", :type => "CNAME", :value => "example.org."},
+      {:name => "@",    :type => "A",     :value => "192.0.2.1"},
+      {:name => "www",  :type => "CNAME", :value => "example.org."},
+      {:name => "mail", :type => "A",     :value => "192.0.2.2"},
+      {:name => "ns",   :type => "A",     :value => "192.0.2.3"},
     ])
 end


### PR DESCRIPTION
I played a bit around with this tool to write zone files first into a
temporary location and verifying them, prior to putting them in the
real zones directory.

I'm not totally sure if it is 100% correct:

- the example.com zone from the tests is accepted with warning
  > example.com/MX 'mail.example.com' has no address records (A or AAAA)
  Not sure, what's wrong here (and if we would have to catch this)
- applied to typo3.org from site-nstypo3org, the deployment fails with
  > zone typo3.org/IN: loading from master file .../typo3.org.zone.test failed:
  >   unexpected end of input
  > zone typo3.org/IN: not loaded due to errors.
  This happens in the following line:
  > dkim._domainkey TXT "v=DKIM1;....
  Not sure, who's right here..